### PR TITLE
added Flags for PSRAM

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+build_flags =
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
 
 
 lib_deps =


### PR DESCRIPTION
needed to compile for PSRAM. Otherwise, the ESP resets itself instantly. (Memory alloc failed). Framebuffer could not be allocated.